### PR TITLE
Реализация ProbeUtilities под Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,5 @@ else()
     message(FATAL_ERROR "Your platform isn't valid\n"
                         "List of supported platforms: \'Linux\', \'Windows\'")
 endif()
+
+target_link_libraries(probe_utilities PUBLIC build_features)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,17 @@ FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download
 FetchContent_MakeAvailable(json)
 target_link_libraries(build_features INTERFACE nlohmann_json::nlohmann_json)
 
-add_library(probe_utilities STATIC src/ProbeUtilities.cpp)
+add_library(probe_utilities STATIC ${CMAKE_SOURCE_DIR}/src/ProbeUtilities.cpp)
 
 if (WIN32)
-    target_sources(probe_utilities PUBLIC src/ProbeUtilsImplWin.cpp)
+    target_sources(probe_utilities PUBLIC 
+                  ${CMAKE_SOURCE_DIR}/src/ProbeUtilsImplWin.cpp)
     target_compile_definitions(probe_utilities PRIVATE TARGET_SYSTEM=0)
 elseif(UNIX)
-    target_sources(probe_utilities PUBLIC src/ProbeUtilsImplLinux.cpp)
+    target_sources(probe_utilities PUBLIC 
+                  ${CMAKE_SOURCE_DIR}/src/ProbeUtilsImplLinux.cpp)
     target_compile_definitions(probe_utilities PRIVATE TARGET_SYSTEM=1)
 else()
     message(FATAL_ERROR "Your platform isn't valid\n"
                         "List of supported platforms: \'Linux\', \'Windows\'")
 endif()
-
-target_link_libraries(probe_utilities PUBLIC build_features)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,3 +43,6 @@ else()
 endif()
 
 target_link_libraries(probe_utilities PUBLIC build_features)
+
+add_executable(main src/main.cpp)
+target_link_libraries(main PUBLIC probe_utilities)

--- a/include/ProbeUtilities.hpp
+++ b/include/ProbeUtilities.hpp
@@ -77,7 +77,10 @@ struct CPUInfo
     std::string arch;
     uint8_t cores;
     std::vector<float> load; // Загрузка каждого ядра
-    uint64_t l1_cache, l2_cache, l3_cache; // capacity
+    uint64_t l1_cache, l2_cache, l3_cache, overall_cache; // capacity, in bytes
+    // overall_cache - cache, берущийся из /proc/cpuinfo на linux
+    uint64_t physid;
+    float clockFreq; // in mhz
 };
 
 struct MemoryInfo

--- a/include/ProbeUtilities.hpp
+++ b/include/ProbeUtilities.hpp
@@ -57,9 +57,9 @@ struct PeripheryInfo
 struct NetworkInterfaceInfo
 {
     std::string name;
-    std::optional<std::array<char, 6>> mac;   // вопросик...
-    std::optional<std::array<char, 4>> ipv4;
-    std::optional<std::array<char, 6>> ipv6;  
+    std::optional<std::array<uint8_t, 6>> mac{std::nullopt};   
+    std::optional<std::array<uint8_t, 4>> ipv4{std::nullopt};
+    std::optional<std::array<uint8_t, 16>> ipv6{std::nullopt};  
     uint8_t ipv4_mask; // хранится в сжатом виде: число единичек
     uint8_t ipv6_mask;
     /* В стандартой библиотеке C++ нет библиотеки для работы с сетью, так что
@@ -77,7 +77,7 @@ struct CPUInfo
     std::string arch;
     uint8_t cores;
     std::vector<float> load; // Загрузка каждого ядра
-    uint32_t l1_cache, l2_cache, l3_cache; // capacity
+    uint64_t l1_cache, l2_cache, l3_cache; // capacity
 };
 
 struct MemoryInfo
@@ -111,6 +111,8 @@ class ProbeUtilities
     std::vector<PeripheryInfo> getPeripheryInfo();
 
     std::vector<NetworkInterfaceInfo> getNetworkInterfaceInfo();
+
+    MemoryInfo getMemoryInfo();
 
     CPUInfo getCPUInfo();
 

--- a/include/ProbeUtilsImplLinux.hpp
+++ b/include/ProbeUtilsImplLinux.hpp
@@ -1,6 +1,9 @@
 #ifndef __PROBE_UTILS_IMPL_LINUX
 #define __PROBE_UTILS_IMPL_LINUX
 #include <ProbeUtilities.hpp>
+#include <unordered_map>
+#include <optional>
+#include <sys/utsname.h>
 
 /*
  * Класс-реализация сканирования системы для ОС Windows
@@ -26,6 +29,11 @@ class ProbeUtilities::ProbeUtilsImpl
     std::vector<NetworkInterfaceInfo> getNetworkInterfaceInfo();
 
     CPUInfo getCPUInfo();
+
+  private:
+    static const std::unordered_map<std::string, decltype(OSInfo::arch)>
+        _OS_BITNESS;
+    std::optional<utsname> _osinfo{std::nullopt};
 };
 
 } // namespace info

--- a/include/ProbeUtilsImplLinux.hpp
+++ b/include/ProbeUtilsImplLinux.hpp
@@ -38,6 +38,10 @@ class ProbeUtilities::ProbeUtilsImpl
     static const std::unordered_set<std::string> _DESIRED_CLASSES;
     std::optional<utsname> _osinfo{std::nullopt};
     std::optional<std::vector<DiscPartitionInfo>> _cached_DPInfo{std::nullopt};
+
+    void _getCPULoadness(CPUInfo &write);
+    void _getCPUCache(CPUInfo &write);
+    void _getCPUBasicInfo(CPUInfo &write);
 };
 
 } // namespace info

--- a/include/ProbeUtilsImplLinux.hpp
+++ b/include/ProbeUtilsImplLinux.hpp
@@ -1,7 +1,9 @@
 #ifndef __PROBE_UTILS_IMPL_LINUX
 #define __PROBE_UTILS_IMPL_LINUX
+#include <nlohmann/json.hpp>
 #include <ProbeUtilities.hpp>
 #include <unordered_map>
+#include <unordered_set>
 #include <optional>
 #include <sys/utsname.h>
 
@@ -33,6 +35,7 @@ class ProbeUtilities::ProbeUtilsImpl
   private:
     static const std::unordered_map<std::string, decltype(OSInfo::arch)>
         _OS_BITNESS;
+    static const std::unordered_set<std::string> _DESIRED_CLASSES;
     std::optional<utsname> _osinfo{std::nullopt};
     std::optional<std::vector<DiscPartitionInfo>> _cached_DPInfo{std::nullopt};
 };

--- a/include/ProbeUtilsImplLinux.hpp
+++ b/include/ProbeUtilsImplLinux.hpp
@@ -30,6 +30,8 @@ class ProbeUtilities::ProbeUtilsImpl
 
     std::vector<NetworkInterfaceInfo> getNetworkInterfaceInfo();
 
+    MemoryInfo getMemoryInfo();
+
     CPUInfo getCPUInfo();
 
   private:

--- a/include/ProbeUtilsImplLinux.hpp
+++ b/include/ProbeUtilsImplLinux.hpp
@@ -34,6 +34,7 @@ class ProbeUtilities::ProbeUtilsImpl
     static const std::unordered_map<std::string, decltype(OSInfo::arch)>
         _OS_BITNESS;
     std::optional<utsname> _osinfo{std::nullopt};
+    std::optional<std::vector<DiscPartitionInfo>> _cached_DPInfo{std::nullopt};
 };
 
 } // namespace info

--- a/include/ProbeUtilsImplLinux.hpp
+++ b/include/ProbeUtilsImplLinux.hpp
@@ -2,7 +2,6 @@
 #define __PROBE_UTILS_IMPL_LINUX
 #include <nlohmann/json.hpp>
 #include <ProbeUtilities.hpp>
-#include <unordered_map>
 #include <unordered_set>
 #include <optional>
 #include <sys/utsname.h>
@@ -35,8 +34,6 @@ class ProbeUtilities::ProbeUtilsImpl
     CPUInfo getCPUInfo();
 
   private:
-    static const std::unordered_map<std::string, decltype(OSInfo::arch)>
-        _OS_BITNESS;
     static const std::unordered_set<std::string> _DESIRED_CLASSES;
     std::optional<utsname> _osinfo{std::nullopt};
     std::optional<std::vector<DiscPartitionInfo>> _cached_DPInfo{std::nullopt};

--- a/src/ProbeUtilities.cpp
+++ b/src/ProbeUtilities.cpp
@@ -37,3 +37,8 @@ info::ProbeUtilities::getNetworkInterfaceInfo()
 }
 
 info::CPUInfo info::ProbeUtilities::getCPUInfo() { return _impl->getCPUInfo(); }
+
+info::MemoryInfo info::ProbeUtilities::getMemoryInfo()
+{
+    return _impl->getMemoryInfo();
+}

--- a/src/ProbeUtilsImplLinux.cpp
+++ b/src/ProbeUtilsImplLinux.cpp
@@ -1,17 +1,61 @@
 #include <ProbeUtilities.hpp>
 #include <ProbeUtilsImplLinux.hpp>
-#include <iostream> // for debugging
+#include <sys/utsname.h>
+#include <stdexcept>
+
 
 using putils = info::ProbeUtilities;
 
-putils::ProbeUtilsImpl::ProbeUtilsImpl()
+// Хардкод по всем возможным значениям uname -m
+const std::unordered_map<std::string, decltype(info::OSInfo::arch)>
+    putils::ProbeUtilsImpl::_OS_BITNESS = {
+        {"alpha", 64},      {"arc", 32},       {"arm", 32},
+        {"aarch64_be", 64}, {"aarch64", 64},   {"armv8b", 32},
+        {"armv8l", 32},     {"blackfin", 32},  {"c6x", 32},
+        {"cris", 32},       {"frv", 32},       {"h8300", 32},
+        {"hexagon", 32},    {"ia64", 64},      {"m32r", 32},
+        {"m68k", 32},       {"metag", 32},     {"microblaze", 32},
+        {"mips", 32},       {"mips64", 64},    {"mn10300", 32},
+        {"nios2", 32},      {"openrisk", 32},  {"parisk", 32},
+        {"parisk64", 64},   {"ppc", 32},       {"ppc64", 64},
+        {"ppcle", 32},      {"ppc64le", 64},   {"s390", 32},
+        {"s390x", 64},      {"score", 32},     {"sh", 32},
+        {"sh64", 64},       {"sparc", 32},     {"sparc64", 64},
+        {"tile", 64},       {"unicore32", 32}, {"i386", 32},
+        {"i686", 32},       {"x86_64", 64},    {"x64", 64},
+        {"xtensa", 32},     {"arm64", 64},     {"amd64", 64},
+        {"i486", 32},       {"i586", 32}};
+
+putils::ProbeUtilsImpl::ProbeUtilsImpl() 
 {
-    std::cout << "compiled for linux" << std::endl;
 }
 
 putils::ProbeUtilsImpl::~ProbeUtilsImpl() {}
 
-info::OSInfo putils::ProbeUtilsImpl::getOSInfo() { return {}; }
+info::OSInfo putils::ProbeUtilsImpl::getOSInfo() 
+{  
+    if (!_osinfo.has_value())
+    {
+        _osinfo.emplace();
+        uname(&_osinfo.value());
+    }
+
+    // Для того, чтобы не писать везде .value();
+    auto &osinfo = _osinfo.value();
+    OSInfo output = {osinfo.sysname, osinfo.nodename, osinfo.release, 0}; 
+
+    try
+    {
+        auto arch = _OS_BITNESS.at(osinfo.machine); 
+        output.arch = arch;
+    }
+    catch (const std::out_of_range &)
+    {
+        output.arch = 0; 
+    }
+
+    return output;
+}
 
 std::vector<info::UserInfo> putils::ProbeUtilsImpl::getUserInfo()
 {

--- a/src/ProbeUtilsImplLinux.cpp
+++ b/src/ProbeUtilsImplLinux.cpp
@@ -370,3 +370,32 @@ void putils::ProbeUtilsImpl::_getCPUBasicInfo(CPUInfo &output)
         if (i == 2) break;
     }
 }
+
+info::MemoryInfo putils::ProbeUtilsImpl::getMemoryInfo()
+{
+    MemoryInfo output;
+    std::ifstream cacheInfoRaw("/proc/meminfo");
+    for (std::string line, it; getline(cacheInfoRaw, line);)
+    {
+        std::stringstream lineParsed(line);
+        if (line.find("MemTotal") != std::string::npos)
+        {
+            // Скипаем 
+            lineParsed >> it;
+            lineParsed >> it;
+            // Там все дается в килобайтах
+            output.capacity = std::stoll(it) * 1024; 
+        }
+        else if (line.find("MemAvailable") != std::string::npos)
+        {
+            // Скипаем 
+            lineParsed >> it;
+            lineParsed >> it;
+            output.freeSpace = std::stoll(it) * 1024; 
+            // Дальше парсить смысла нет
+            break;
+        }
+    }
+    return output;
+}
+

--- a/src/ProbeUtilsImplLinux.cpp
+++ b/src/ProbeUtilsImplLinux.cpp
@@ -136,7 +136,7 @@ std::vector<info::PeripheryInfo> putils::ProbeUtilsImpl::getPeripheryInfo()
     {
         // generic используется в lshw, когда не указано класса
         auto cls = entry.value("class", std::string("generic"));
-        if (_DESIRED_CLASSES.count(cls))
+        if (_DESIRED_CLASSES.count(cls) != 0)
         {
             std::string name;
 
@@ -183,7 +183,7 @@ putils::ProbeUtilsImpl::getNetworkInterfaceInfo()
         curIF.name = interface["ifname"].get<std::string>();
 
         // Если address не указан, продолжать дальше нет смысла
-        if (interface.count("address"))
+        if (interface.contains("address"))
         {
             std::stringstream macraw(interface["address"].get<std::string>());
             std::array<uint8_t, 6> mac;
@@ -197,7 +197,7 @@ putils::ProbeUtilsImpl::getNetworkInterfaceInfo()
         }
 
         // Ищем ip-адреса
-        if (interface.count("addr_info"))
+        if (interface.contains("addr_info"))
         {
             // Если поле addr_info есть, то остальные аттрибуты также
             // указываются утилитой ip, значит, можно не оборачивать их в value

--- a/src/ProbeUtilsImplLinux.cpp
+++ b/src/ProbeUtilsImplLinux.cpp
@@ -344,7 +344,27 @@ void putils::ProbeUtilsImpl::_getCPUBasicInfo(CPUInfo &output)
                 std::string(line.begin() + line.find(":") + 2, line.end()));
             ++i;
         }
-        if (i == 2) break;
+        else if (line.find("physical id") != std::string::npos)
+        {
+            output.physid = std::stoi(
+                std::string(line.begin() + line.find(":") + 2, line.end()));
+            ++i;
+        }
+        else if (line.find("cpu MHz") != std::string::npos)
+        {
+            output.clockFreq = std::stof(
+                std::string(line.begin() + line.find(":") + 2, line.end()));
+            ++i;
+        }
+        else if (line.find("cache size") != std::string::npos)
+        {
+            // Я надеюсь, что вывод /proc/cpuinfo не поменяется
+            output.overall_cache = std::stoi(
+                std::string(line.begin() + line.find(":") + 2, line.end() - 3));
+            output.overall_cache *= 1024;
+            ++i;
+        }
+        if (i == 5) break;
     }
 }
 

--- a/src/ProbeUtilsImplLinux.cpp
+++ b/src/ProbeUtilsImplLinux.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <netinet/in.h>
 #include <sys/utsname.h>
-#include <stdexcept>
 #include <thread>
 #include <utmp.h>
 #include <chrono>
@@ -13,32 +12,13 @@
 #include <nlohmann/json.hpp>
 #include <cstdlib>
 #include <arpa/inet.h>
+#include <unistd.h>
 
 
 
 using putils = info::ProbeUtilities;
 using namespace nlohmann;
 using namespace std::chrono_literals;
-
-// Хардкод по всем возможным значениям uname -m
-const std::unordered_map<std::string, decltype(info::OSInfo::arch)>
-    putils::ProbeUtilsImpl::_OS_BITNESS = {
-        {"alpha", 64},      {"arc", 32},       {"arm", 32},
-        {"aarch64_be", 64}, {"aarch64", 64},   {"armv8b", 32},
-        {"armv8l", 32},     {"blackfin", 32},  {"c6x", 32},
-        {"cris", 32},       {"frv", 32},       {"h8300", 32},
-        {"hexagon", 32},    {"ia64", 64},      {"m32r", 32},
-        {"m68k", 32},       {"metag", 32},     {"microblaze", 32},
-        {"mips", 32},       {"mips64", 64},    {"mn10300", 32},
-        {"nios2", 32},      {"openrisk", 32},  {"parisk", 32},
-        {"parisk64", 64},   {"ppc", 32},       {"ppc64", 64},
-        {"ppcle", 32},      {"ppc64le", 64},   {"s390", 32},
-        {"s390x", 64},      {"score", 32},     {"sh", 32},
-        {"sh64", 64},       {"sparc", 32},     {"sparc64", 64},
-        {"tile", 64},       {"unicore32", 32}, {"i386", 32},
-        {"i686", 32},       {"x86_64", 64},    {"x64", 64},
-        {"xtensa", 32},     {"arm64", 64},     {"amd64", 64},
-        {"i486", 32},       {"i586", 32}};
 
 const std::unordered_set<std::string> putils::ProbeUtilsImpl::_DESIRED_CLASSES =
     {"multimedia", "communication", "printer", "input", "display"};
@@ -60,16 +40,7 @@ info::OSInfo putils::ProbeUtilsImpl::getOSInfo()
     // Для того, чтобы не писать везде .value();
     auto &osinfo = _osinfo.value();
     OSInfo output = {osinfo.sysname, osinfo.nodename, osinfo.release, 0}; 
-
-    try
-    {
-        auto arch = _OS_BITNESS.at(osinfo.machine); 
-        output.arch = arch;
-    }
-    catch (const std::out_of_range &)
-    {
-        output.arch = 0; 
-    }
+    output.arch = sysconf(_SC_LONG_BIT);
 
     return output;
 }

--- a/src/ProbeUtilsImplLinux.cpp
+++ b/src/ProbeUtilsImplLinux.cpp
@@ -178,9 +178,7 @@ putils::ProbeUtilsImpl::getNetworkInterfaceInfo()
         curIF.ipv4 = std::nullopt;
         curIF.ipv6 = std::nullopt;
         curIF.mac = std::nullopt;
-
-
-        curIF.name = interface["ifname"].get<std::string>();
+        curIF.name = interface.value("ifname", std::string());
 
         // Если address не указан, продолжать дальше нет смысла
         if (interface.contains("address"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,8 @@ void __test_UserInfo(info::ProbeUtilities& probe)
         std::cout << "Last log time: " << std::ctime(&epoch_time);
         std::cout
             << "Uptime: "
-            << std::chrono::duration_cast<std::chrono::hours>(d.uptime).count()
+            << std::chrono::duration_cast<std::chrono::minutes>(d.uptime).count()
+            << " minutes"
             << std::endl;
         std::cout << std::endl;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,169 @@
+#include "ProbeUtilities.hpp"
+#include <ctime>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+
+
+/*
+ *
+ * Пример того, как будет выводиться информация библиотекой
+ *
+ */
+
+void __test_OSInfo(info::ProbeUtilities& probe) 
+{
+    std::cout << "\n------TestOSInfo------\n";
+    info::OSInfo result = probe.getOSInfo();
+    std::cout << "OS Name: " << result.name << std::endl;
+    std::cout << "Version: " << result.hostname << std::endl;
+    std::cout << "Kernel: " << result.kernel << std::endl;
+    std::cout << "Arch: " << result.arch << std::endl;
+}
+
+void __test_DiscPartitionInfo(info::ProbeUtilities& probe) 
+{
+    std::cout << "\n------TestDiscPartitionInfo------\n";
+    std::vector<info::DiscPartitionInfo> result = probe.getDiscPartitionInfo();
+    for (const auto& d: result) {
+        std::cout << "Name: " << d.name << std::endl;
+        std::cout << "MountPoint: " << d.mountPoint << std::endl;
+        std::cout << "Filesystem: " << d.filesystem << std::endl;
+        std::cout << "Capacity: " << d.capacity << std::endl;
+        std::cout << "FreeSpace: " << d.freeSpace << std::endl;
+        std::cout << "------------------" << std::endl;
+    }
+}
+
+void __test_UserInfo(info::ProbeUtilities& probe)
+{
+    std::cout << "\n------TestUserInfo------\n";
+    auto result = probe.getUserInfo();
+    for (const auto& d: result) {
+        std::cout << "Name: " << d.name << std::endl;
+        std::time_t epoch_time =
+            std::chrono::system_clock::to_time_t(d.lastLog);
+        std::cout << "Last log time: " << std::ctime(&epoch_time);
+        std::cout
+            << "Uptime: "
+            << std::chrono::duration_cast<std::chrono::hours>(d.uptime).count()
+            << std::endl;
+        std::cout << std::endl;
+    }
+}
+
+void __test_CPUInfo(info::ProbeUtilities& probe)
+{
+    std::cout << "\n------TestCPUInfo------\n";
+    auto info = probe.getCPUInfo();
+    std::cout << "Name: " << info.name << std::endl;
+    std::cout << "Architecture: " << info.arch << std::endl;
+    std::cout << "Number of cores: " << (int)info.cores << std::endl;
+    std::cout << "L1 cache: " << info.l1_cache / 1024.f << " kb" << std::endl;
+    std::cout << "L2 cache: " << info.l2_cache / 1024.f << " kb" << std::endl;
+    std::cout << "L3 cache: " << info.l3_cache / 1024.f << " kb" << std::endl;
+    std::cout << "Overall cache: " << info.overall_cache / 1024.f << " kb"
+              << std::endl;
+    std::cout << "Clock frequency: " << info.clockFreq << " mhz" << std::endl;
+    std::cout << "physid: " << info.physid << std::endl;
+    std::cout << std::endl;
+
+    for (std::size_t i = 0; i < info.load.size(); ++i)
+    {
+        std::cout << "Loadness of core number " << i << ": "
+                  << info.load[i] * 100 << "%" << std::endl;
+    }
+}
+
+void __test_NetworkInterfaceInfo(info::ProbeUtilities& probe)
+{
+    std::cout << "\n------TestNetworkInterfaceInfo------\n";
+    auto users = probe.getNetworkInterfaceInfo();
+
+    // Печатает содержимое буфера без последнего символа и
+    // очищает буфер
+    auto printSSBuffer = [](std::stringstream &s)
+    {
+        std::string output = s.str();
+        output.pop_back();
+        std::cout << output;
+        s.str("");
+    };
+
+    for (auto &part: users)
+    {
+        std::cout << "Name: " << part.name << std::endl;
+        std::stringstream fs;
+        if (part.mac)
+        {
+            std::cout << "MAC: ";
+            for (auto i: part.mac.value())
+            {
+                fs << std::hex << (int)i << ":";
+            }
+
+            printSSBuffer(fs);
+            fs << std::dec;
+            std::cout << std::endl;
+        }
+
+        if (part.ipv4)
+        {
+            std::cout << "IPv4: ";
+            for (auto i : part.ipv4.value())
+            {
+                fs << (int)i << ".";
+            }
+            printSSBuffer(fs);
+            std::cout << "/" << (int)part.ipv4_mask << std::endl;
+        }
+
+        if (part.ipv6)
+        {
+            std::cout << "IPv6: ";
+            for (auto i : part.ipv6.value())
+            {
+                fs << std::hex << (int)i << ":";
+            }
+            printSSBuffer(fs);
+            fs << std::dec;
+            std::cout << "/" << (int)part.ipv6_mask << std::endl;
+        }
+        std::cout << std::endl;
+    }
+}
+
+void __test_PeripheryInfo(info::ProbeUtilities& probe)
+{
+    std::cout << "\n------TestPeripheryInfo------\n";
+    auto info = probe.getPeripheryInfo();
+    for (const auto &i: info)
+    {
+        std::cout << "Name: " << i.name << std::endl;
+        std::cout << "Type: " << i.type << std::endl;
+        std::cout << std::endl;
+    }
+}
+
+void __test_MemoryInfo(info::ProbeUtilities& probe)
+{
+    std::cout << "\n------TestMemoryInfo------\n";
+    auto info = probe.getMemoryInfo();
+    std::cout << "Capacity: " << info.capacity / 1024.f / 1024.f << "mB"
+              << std::endl;
+
+    std::cout << "Free space: " << info.freeSpace / 1024.f / 1024.f << "mB"
+              << std::endl;
+}
+
+int main() {
+    info::ProbeUtilities probe;
+    __test_OSInfo(probe);
+    __test_UserInfo(probe);
+    __test_DiscPartitionInfo(probe);
+    __test_NetworkInterfaceInfo(probe);
+    __test_PeripheryInfo(probe);
+    __test_CPUInfo(probe);
+    __test_MemoryInfo(probe);
+    return 0;
+}


### PR DESCRIPTION
В ветке содержится полностью реализованная библиотека ProbeUtilities под линукс. Все функции прошли ручное тестирование только на моем компьютере, так что я не знаю, как та или иная функция поведет себя в других дистрибутивах. По идее, все должно быть норм. Так что, приглашаю всех неравнодушных потестить библиотеку на своих системах. Инструкция по сборке есть в первом PR

Также, стоит отметить, что в этом PR я поменял интерфейс ProbeUtilities.hpp и CMakeLists.txt. Изменения:
- В NetworkInterfaceInfo теперь хранимые типы uint8_t
- Там же, размер ipv6 увеличен до 16 байт. Оказывается, столько занимает ipv6-адрес
- Размеры кешей увеличены до uint64_t
- Добавлен метод getMemoryInfo
- Добавлены поля overall_cache, physid, и clockFreq в структуру CPUInfo

Также, добавлен main для демонстрационных целей. Его лучше запускать из-под sudo - это необходимо для вызова утилиты lshw